### PR TITLE
Replace assertRaises with assertRaisesRegex in isbn_tests.py

### DIFF
--- a/tests/isbn_tests.py
+++ b/tests/isbn_tests.py
@@ -39,6 +39,13 @@ class TestCosmeticChangesISBN(DefaultDrySiteTestCase):
 
     """Test CosmeticChanges ISBN fix."""
 
+    ISBN_DIGITERROR_RE = 'ISBN [0-9]+ is not [0-9]+ digits long'
+    ISBN_INVALIDERROR_RE = 'Invalid ISBN found'
+    ISBN_CHECKSUMERROR_RE = 'ISBN checksum of [0-9]+ is incorrect'
+    ISBN_INVALIDCHECKERROR_RE = 'checksum or check digit is invalid'
+    ISBN_INVALIDCHARERROR_RE = 'ISBN [0-9a-zA-Z]+ contains invalid characters'
+    ISBN_INVALIDLENGTHERROR_RE = 'The number has an invalid length'
+
     def test_valid_isbn(self):
         """Test ISBN."""
         cc = CosmeticChangesToolkit(self.site, namespace=0)
@@ -54,17 +61,30 @@ class TestCosmeticChangesISBN(DefaultDrySiteTestCase):
         cc = CosmeticChangesToolkit(self.site, namespace=0)
 
         # Invalid characters
-        self.assertRaises(AnyIsbnValidationException,
-                          cc.fix_ISBN, 'ISBN 0975229LOL')
+        self.assertRaisesRegex(AnyIsbnValidationException,
+                               (self.ISBN_DIGITERROR_RE + '|' +
+                                self.ISBN_INVALIDERROR_RE + '|' +
+                                self.ISBN_INVALIDLENGTHERROR_RE),
+                               cc.fix_ISBN, 'ISBN 0975229LOL')
         # Invalid checksum
-        self.assertRaises(AnyIsbnValidationException,
-                          cc.fix_ISBN, 'ISBN 0975229801')
+        self.assertRaisesRegex(AnyIsbnValidationException,
+                               (self.ISBN_CHECKSUMERROR_RE + '|' +
+                                self.ISBN_INVALIDERROR_RE + '|' +
+                                self.ISBN_INVALIDLENGTHERROR_RE + '|' +
+                                self.ISBN_INVALIDCHECKERROR_RE),
+                               cc.fix_ISBN, 'ISBN 0975229801')
         # Invalid length
-        self.assertRaises(AnyIsbnValidationException,
-                          cc.fix_ISBN, 'ISBN 09752298')
+        self.assertRaisesRegex(AnyIsbnValidationException,
+                               (self.ISBN_DIGITERROR_RE + '|' +
+                                self.ISBN_INVALIDERROR_RE + '|' +
+                                self.ISBN_INVALIDLENGTHERROR_RE),
+                               cc.fix_ISBN, 'ISBN 09752298')
         # X in the middle
-        self.assertRaises(AnyIsbnValidationException,
-                          cc.fix_ISBN, 'ISBN 09752X9801')
+        self.assertRaisesRegex(AnyIsbnValidationException,
+                               (self.ISBN_INVALIDCHARERROR_RE + '|' +
+                                self.ISBN_INVALIDERROR_RE + '|' +
+                                self.ISBN_INVALIDLENGTHERROR_RE),
+                               cc.fix_ISBN, 'ISBN 09752X9801')
 
     def test_ignore_invalid_isbn(self):
         """Test fixing ISBN numbers with an invalid ISBN."""


### PR DESCRIPTION
assertRaises is not as good of a test as assertRaisesRegex.
The latter has an extra parameter to match the exception message,
allowing more precision when checking an error.

Change restored after revert in Ib41b30

Bug: T154281
Change-Id: Id67d5b76c0dc5a70289478d842cd3ebdc28b1b85